### PR TITLE
docs(models): deprecate unloadable legacy xgb_*.model artifacts

### DIFF
--- a/models/DEPRECATED.md
+++ b/models/DEPRECATED.md
@@ -8,7 +8,7 @@ These three files are stored in XGBoost's **legacy binary format**, which was
 deprecated in XGBoost 1.6 and **removed in 3.1**. Verified 2026-08-27 against R
 `xgboost` 3.2.1.1 — every one of them fails to load:
 
-```
+```text
 Failed to load model: .../xgb_wp_spread_model.model
 The binary format has been deprecated in 1.6 and removed in 3.1, use UBJ or JSON
 instead.

--- a/models/DEPRECATED.md
+++ b/models/DEPRECATED.md
@@ -1,0 +1,54 @@
+# Deprecated model artifacts in this directory
+
+## `xgb_ep_model.model` · `xgb_wp_naive_model.model` · `xgb_wp_spread_model.model`
+
+**Status: deprecated, unusable, retained only for archaeology. Do not consume.**
+
+These three files are stored in XGBoost's **legacy binary format**, which was
+deprecated in XGBoost 1.6 and **removed in 3.1**. Verified 2026-08-27 against R
+`xgboost` 3.2.1.1 — every one of them fails to load:
+
+```
+Failed to load model: .../xgb_wp_spread_model.model
+The binary format has been deprecated in 1.6 and removed in 3.1, use UBJ or JSON
+instead.
+```
+
+There is no supported XGBoost release that can both read these files and be
+installed today, so they cannot be revived by re-saving; they would have to be
+retrained.
+
+**Superseded by** the `cfb_model_artifacts` bundle, which ships modern `.ubj`
+artifacts read by *both* `cfbfastR` and `sportsdataverse-py`:
+
+<https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts>
+
+That bundle carries `ep_model`, `wp_naive`, `wp_spread`, `fg_model`,
+`cfb_cp_model`, `qbr_model`, `fd_model`, `two_pt_model`, `xpass_model`, the
+punt/field-position lookup tables, model cards, and a `MANIFEST.json` with
+per-asset `sha256`, the feature contract of every booster, and the EP next-score
+class order. Publishing there updates both libraries in one change.
+
+Context and migration plan: [cfbfastR#138](https://github.com/sportsdataverse/cfbfastR/issues/138).
+
+## `ep_model.Rdata` · `fg_model.Rdata` · `wp_model.Rdata`
+
+**Status: live today, scheduled for replacement.**
+
+These are what `cfbfastR::.onLoad()` currently downloads (`nnet::multinom` EP,
+`mgcv::bam` FG and WP). They still work, with one known defect: the EP model
+aborts on mid-era CFBD data — `predict.nnet(): missing values in 'x'` for
+seasons ~2006–2013 whenever `epa_wpa = TRUE`
+([cfbfastR#5](https://github.com/sportsdataverse/cfbfastR/issues/5)).
+
+They are scheduled to be replaced by the `cfb_model_artifacts` bundle above
+(cfbfastR#138 P1/P2). **Do not delete them until that migration has landed and
+been released** — every currently-published cfbfastR EPA/WPA number was produced
+by these files, so they are the reproduction path for existing datasets.
+
+⚠️ The replacement is **not** a drop-in: the `.ubj` EP model uses one-hot
+`down_1..down_4` plus raw `distance` (no `log_ydstogo` / `Goal_To_Go` /
+`Under_two` / interactions), and — critically — its 7 next-score classes are in
+a **different order** than `ep_model$lev`, with no fixed point between the two
+orderings. Consult `MANIFEST.json`'s `ep_class_contract` before scoring anything
+with it.


### PR DESCRIPTION
Adds `models/DEPRECATED.md`. No files deleted.

The three `xgb_*.model` files are in XGBoost's legacy binary format — deprecated in 1.6, **removed in 3.1** — and were verified unloadable against R xgboost 3.2.1.1 on 2026-08-27. They can't be revived by re-saving (no installable XGBoost can read them), so they'd have to be retrained. They're superseded by the new [`cfb_model_artifacts`](https://github.com/sportsdataverse/sportsdataverse-data/releases/tag/cfb_model_artifacts) bundle that both cfbfastR and sportsdataverse-py will read from.

The note also flags the `.Rdata` trio as live-but-scheduled-for-replacement (cfbfastR#138), and explicitly says **not** to delete them until that migration ships — they're the reproduction path for every currently-published cfbfastR EPA/WPA number.

Kept as a note rather than a deletion deliberately.

## Summary by Sourcery

Document deprecated model artifacts and provide migration and retention guidance without deleting existing files.

Enhancements:
- Document the legacy XGBoost model artifacts as deprecated and unusable, identify their modern replacement bundle, and preserve guidance for migrating the still-live Rdata models.

Documentation:
- Add models/DEPRECATED.md with status, compatibility, replacement, and retention guidance for the legacy XGBoost and current Rdata model artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation cataloging available model artifacts.
  * Identified legacy model files that are no longer supported and documented their replacement.
  * Documented active models, including a known limitation affecting expected-points data and planned updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->