### PR TITLE
fix(daily_cfb): restore cfb/ writes and stop the job going green when a stage dies

### DIFF
--- a/.github/workflows/daily_cfb.yml
+++ b/.github/workflows/daily_cfb.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v5
         with:
+          # NOTE: every non-empty line below is passed straight to
+          # `git sparse-checkout` as a pattern -- do not put comments inside the
+          # block. cfb/schedules is required because espn_cfb_02 rebuilds the
+          # master schedule by listing every file in cfb/schedules/rds; without
+          # the history it is silently rebuilt from the single year in this run
+          # (18MB). The other cfb/ subtrees -- pbp (1.1GB), roster, team_box,
+          # player_box -- are write-only, so the driver creates them instead.
           sparse-checkout: |
             .
             scripts
@@ -63,6 +70,7 @@ jobs:
             R
             rosters
             schedules
+            cfb/schedules
       - name: Setting up R
         uses: r-lib/actions/setup-r@v2
         with:

--- a/scripts/daily_cfb_R_processor.sh
+++ b/scripts/daily_cfb_R_processor.sh
@@ -45,17 +45,45 @@ do
         r) RESCRAPE=${OPTARG};;
     esac
 done
+# The workflow checks out cfb/ sparsely (only cfb/schedules, which stage 02 reads
+# back). Every other cfb/ output dir is write-only and absent from the runner, and
+# saveRDS()/write_parquet() do NOT create parent dirs -- they fail with
+# "cannot open the connection". That is what silently emptied cfbfastR_cfb_pbp
+# from 2026-07-01 onward while the job stayed green.
+mkdir -p \
+  cfb/pbp/rds cfb/pbp/parquet \
+  cfb/schedules/rds cfb/schedules/parquet \
+  cfb/team_box/rds cfb/team_box/parquet \
+  cfb/player_box/rds cfb/player_box/parquet \
+  cfb/roster/rds cfb/roster/parquet cfb/roster/csv
+
+# An R stage that dies prints "Execution halted" and exits non-zero, but the loop
+# below used to ignore that and commit whatever happened to be on disk -- a green
+# job publishing nothing. Record the failure and fail the run at the end.
+# Stages are NOT skipped on an upstream failure: 02/03 read the schedules 01
+# writes, so they fail too and each reports itself.
+run_stage() {
+  local label="$1"; shift
+  local rc=0
+  "$@" || rc=$?
+  if [ "$rc" != "0" ]; then
+    echo "::error ::${label} failed (exit ${rc}) -- output for this year is incomplete"
+    STAGE_RC=1
+  fi
+  return "$rc"
+}
+
 for i in $(seq "${START_YEAR}" "${END_YEAR}")
 do
     echo "$i"
     git pull  >> /dev/null
     git config --local user.email "action@github.com"
     git config --local user.name "Github Action"
-    Rscript week.R -s $i -e $i
-    Rscript R/espn_cfb_01_pbp_creation.R -s $i -e $i
-    Rscript R/espn_cfb_02_team_box_creation.R -s $i -e $i
-    Rscript R/espn_cfb_03_player_box_creation.R -s $i -e $i
-    Rscript R/espn_cfb_04_roster_creation.R -s $i -e $i
+    run_stage "week.R ($i)"            Rscript week.R -s $i -e $i
+    run_stage "espn_cfb_01_pbp ($i)"   Rscript R/espn_cfb_01_pbp_creation.R -s $i -e $i
+    run_stage "espn_cfb_02_team ($i)"  Rscript R/espn_cfb_02_team_box_creation.R -s $i -e $i
+    run_stage "espn_cfb_03_player ($i)" Rscript R/espn_cfb_03_player_box_creation.R -s $i -e $i
+    run_stage "espn_cfb_04_roster ($i)" Rscript R/espn_cfb_04_roster_creation.R -s $i -e $i
     sdv_commit_push "CFB Data Update (Start: $i End: $i)" . || PUSH_RC=1
 done
 
@@ -63,5 +91,10 @@ done
 # separate path and can succeed while the repo mirror is left stale.
 if [ "${PUSH_RC:-0}" != "0" ]; then
   echo "::error ::At least one commit failed to reach origin; the repo mirror is stale."
+  exit 1
+fi
+
+if [ "${STAGE_RC:-0}" != "0" ]; then
+  echo "::error ::At least one R stage failed; released assets for the affected year are incomplete or stale."
   exit 1
 fi


### PR DESCRIPTION
## What this fixes

`daily_cfb.yml`'s sparse-checkout lists `. scripts .github betting data models player_stats R rosters schedules`. **`cfb/` is a tracked top-level directory and is not in that list.**

All four `espn_cfb_0*.R` stages write under `cfb/`, and `saveRDS()` / `arrow::write_parquet()` do not create parent directories:

```
Error in `purrr::map()`: Caused by error in `gzfile()`:
! cannot open the connection
  ... cfb_pbp_games(y) -> saveRDS(sched, "cfb/schedules/rds/cfb_schedule_{y}.rds")
Execution halted
```

Each stage is a separate `Rscript` whose exit code the driver ignored, so the loop continued and committed whatever was on disk. Green job, nothing published. Same class as the sparse-checkout failures in `nfl-data` #27 and `wehoop-wnba-stats-data` — third instance.

This is also why `espn_cfb_team_boxscores` and `espn_cfb_player_boxscores` have **0 assets** despite being created on 2026-08-27: stage 02/03 upload to them and both die at the first write.

## What this does NOT fix — corrected

An earlier version of this description claimed this PR restores `cfbfastR_cfb_pbp`. **That is wrong, and the correction matters**, so it is recorded here rather than quietly edited away.

`cfbfastR_cfb_pbp` is uploaded by `week.R:977`, and `week.R` runs **first** in the driver, before the four stages this PR repairs. It dies much earlier, at `week.R:349`:

```
Error in `dplyr::left_join()`:
! Join columns in `x` must be present in the data.
✖ Problem with `sack_player_id`.
Execution halted
```

preceded by thousands of `Invalid arguments or no play-level player stats data available` and `NAs introduced by coercion` on `sack_player_id = as.integer(sack_player_id)` (`week.R:219`).

So the play-level player-stats source is returning nothing for 2026, `sack_player_id` never exists on the frame, the roster join chain at 335-355 aborts, and week.R halts **628 lines before** the pbp upload. Timestamps in run 34029699892 confirm the ordering: left_join dies at 11:26:18, the `gzfile` error in stage 01 at 11:26:20.

**`cfbfastR::load_cfb_pbp()` will still return no 2026 data after this merges.** That needs a separate fix at the data-source level — and note the CFBD caveat that an empty frame means either "no data" or "server overloaded", so the probe has to distinguish them rather than treating `nrow() == 0` as truth.

What this PR *does* change for that bug: it will now surface as a **red run** instead of being swallowed.

## The changes

**1. Add `cfb/schedules` to the sparse-checkout — and only that subtree.**

Stage 02 rebuilds the master schedule by listing *every* file in `cfb/schedules/rds`, so without the history it would silently rebuild the master from the single year in the current run. That subtree is 18MB. The other `cfb/` subtrees are write-only — nothing reads them back — and `cfb/pbp` alone is **1.1GB**, so the driver `mkdir -p`s them instead.

| subtree | size | treatment |
|---|--:|---|
| `cfb/schedules` | 18 MB | checked out (stage 02 reads the history) |
| `cfb/pbp` | 1,074 MB | `mkdir -p` (write-only) |
| `cfb/roster` | 54 MB | `mkdir -p` (write-only) |
| `cfb/team_box`, `cfb/player_box` | — | `mkdir -p` (write-only) |

The comments sit *outside* the block scalar deliberately: `actions/checkout` passes every non-empty line straight to `git sparse-checkout`, so a `#` line becomes a pattern rather than a comment.

**2. Fail the run when a stage dies.** Each `Rscript` is wrapped in `run_stage()`, which records a non-zero exit and fails the run at the end, alongside the existing push-failure check added after the wehoop/hoopR incident. Stages are deliberately **not** skipped on an upstream failure: 02 and 03 read the schedules 01 writes, so they fail on their own and each reports itself.

## Verification

- `bash -n scripts/daily_cfb_R_processor.sh` — clean.
- Workflow YAML parses; the sparse list resolves to 11 patterns with **no comment leakage** into `git sparse-checkout`.
- `run_stage` behaviour tested both directions: a failing stage emits the annotation with the correct exit code, does **not** abort the loop, and the run exits 1; with all stages passing the run exits 0.
- The `mkdir -p` list is an exact **11/11** match against the directories the four stage scripts write to — no gaps, no extras.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved daily college football data processing by ensuring required output locations are available before processing begins.
  - Processing now reports individual stage failures and correctly marks the overall run as failed when any stage encounters an error.
  - Schedule data is now included in the files available during daily processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->