### PR TITLE
fix(week): halve CFBD concurrency and make it env-tunable

### DIFF
--- a/.github/workflows/daily_cfb.yml
+++ b/.github/workflows/daily_cfb.yml
@@ -100,6 +100,11 @@ jobs:
         shell: bash
         env:
           GITHUB_PAT: ${{ secrets.SDV_GH_TOKEN }}
+          # CFBD request concurrency for week.R. Unset is fine -- the script
+          # falls back to its own default, as it does for any non-numeric or
+          # < 1 value. Set the repository variable CFBD_WORKERS to re-tune the
+          # pace from the GitHub UI without touching code.
+          CFBD_WORKERS: ${{ vars.CFBD_WORKERS }}
         run: |
           echo $(pwd)
           bash scripts/daily_cfb_R_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}

--- a/week.R
+++ b/week.R
@@ -12,6 +12,24 @@ library(glue)
 library(optparse)
 
 
+# CFBD request concurrency ------------------------------------------------
+#
+# Every worker is an independent CFBD caller, so this is a rate-limit dial, not
+# just a speed dial. At 3 workers the 2026-09-06 run took HTTP 429 sixty-three
+# times from cfbd_play_stats_player(); cfbfastR reported each one as "no
+# play-level player stats data available", sack_player_id never materialised,
+# and the roster join below aborted the script 628 lines before the
+# cfbfastR_cfb_pbp upload. cfbfastR_cfb_pbp published nothing from 2026-07-01.
+#
+# Env-tunable rather than hardcoded so the pace can be re-tuned without a code
+# change, per the repo convention for rate limits. CFBD_WORKERS overrides;
+# anything unset, non-numeric or < 1 falls back to the argument.
+cfbd_workers <- function(default) {
+  n <- suppressWarnings(as.integer(Sys.getenv("CFBD_WORKERS", "")))
+  if (is.na(n) || n < 1L) default else n
+}
+
+
 option_list <- list(
   make_option(
     c("-s", "--start_year"),
@@ -50,7 +68,7 @@ yr_epa_start_time <- proc.time()
 
 
 if (interactive()) {
-  future::plan("multisession", workers = 8)
+  future::plan("multisession", workers = cfbd_workers(8))
   progressr::with_progress({
     p <- progressr::progressor(along = y)
     
@@ -73,7 +91,7 @@ if (interactive()) {
   future::plan("sequential")
 } else {
   # Non-interactive version
-  future::plan("multisession", workers = 3)
+  future::plan("multisession", workers = cfbd_workers(2))
   progressr::with_progress({
     p <- progressr::progressor(along = y)
     
@@ -164,7 +182,7 @@ arrow::write_parquet(
 df_game_ids <- unique(pbp_df$game_id)
 
 if (interactive()) {
-  future::plan("multisession", workers = 8)
+  future::plan("multisession", workers = cfbd_workers(8))
   progressr::with_progress({
     p <- progressr::progressor(along = df_game_ids)
     df_player_stats <- furrr::future_map_dfr(
@@ -182,7 +200,7 @@ if (interactive()) {
   future::plan("sequential")
 } else {
   # Non-interactive version
-  future::plan("multisession", workers = 3)
+  future::plan("multisession", workers = cfbd_workers(2))
   progressr::with_progress({
     p <- progressr::progressor(along = df_game_ids)
     df_player_stats <- furrr::future_map_dfr(


### PR DESCRIPTION
Companion to **[cfbfastR#148](https://github.com/sportsdataverse/cfbfastR/pull/148)**. Together they close the `cfbfastR_cfb_pbp` outage that #20 diagnosed but did not fix.

## Why

Every `future` worker in `week.R` is an independent CFBD caller, so the worker count is a **rate-limit dial**, not just a speed dial.

At 3 workers the 2026-09-06 run took **HTTP 429 sixty-three times** from `cfbd_play_stats_player()`. cfbfastR reports each 429 as `"no play-level player stats data available"`, so `df_player_stats` came back without `sack_player_id`, the roster join at `week.R:349` aborted with `Join columns in `x` must be present in the data`, and the script died **628 lines before** the `cfbfastR_cfb_pbp` upload at `week.R:977`.

That release has published nothing since **2026-07-01** and has **no `play_by_play_2026` asset at all** — `cfbfastR::load_cfb_pbp()` returns nothing for the current season.

## The change

CI default drops **3 → 2**. Interactive keeps 8 — a human running this isn't competing with a scheduled job.

Both go through `cfbd_workers()`, which reads `CFBD_WORKERS` and falls back to the supplied default when it's unset, empty, non-numeric or `< 1`. Rate limits stay tunable by env rather than hardcoded.

The workflow passes `vars.CFBD_WORKERS` through, so the pace is re-tunable **from the GitHub UI without a code change** — an env var the workflow never forwards is only *theoretically* tunable. An unset repository variable arrives as an empty string, which is exactly the tested fallback case.

## Scope

`week.R` only. The `espn_cfb_0*.R` stages also call `future::plan()`, but they make **zero `cfbd_*` calls** (verified) — different host, different limit, not implicated.

## This is the mitigation, not the resilience

Lower concurrency reduces how often the limit is provoked. The actual fix is **cfbfastR#148**, which raises the shared retry budget in `get_req()` from 3 tries / ~9s to 6 tries / 120s, inherited by all 28 CFBD callers.

`week.R` line 1 is `remotes::install_github("sportsdataverse/cfbfastR")`, so this job picks up #148 automatically once it merges — no pin to bump.

## Verification

- `week.R` parses.
- `cfbd_workers()` exercised across all eight branches: unset, `""`, `"abc"`, `"0"`, `"-3"` → default; `"1"` → 1, `"4"` → 4, `"2.9"` → 2.
- Workflow YAML parses with both `env` entries resolving.

## Sequencing

Merge **#148 first** if you want the next run to have both. This PR alone reduces the 429 rate; #148 alone makes the job survive the 429s. Either helps; both together is the fix.

## Summary by Sourcery

Make weekly CFBD processing rate-limit aware by lowering scheduled concurrency and exposing worker control through the environment.

Bug Fixes:
- Reduce scheduled CFBD request concurrency to mitigate rate-limit failures during weekly processing.

Enhancements:
- Make CFBD worker counts configurable through the CFBD_WORKERS environment variable while retaining safe defaults for invalid values and separate interactive defaults.

CI:
- Forward the repository-level CFBD_WORKERS variable to the daily workflow so request pacing can be adjusted without code changes.