### PR TITLE
fix: restore the 2026 CFB data run (player-id collision + roster parquet)

### DIFF
--- a/R/espn_cfb_04_roster_creation.R
+++ b/R/espn_cfb_04_roster_creation.R
@@ -46,8 +46,11 @@ games <- purrr::map(years_vec, function(x) {
     # list type and write_parquet() aborts with "Invalid: cannot convert",
     # which is what failed the 2026-09-07 run at espn_cfb_04_roster.
     #
-    # Coercing every element to integer is lossless here: all 12,127 character
-    # values are plain numeric id strings, with none non-coercible and no ""/NA.
+    # Coercing every element to integer is lossless here: those 12,121
+    # character ELEMENTS hold 12,127 individual VALUES between them (element
+    # lengths are 1 or 2), and all 12,127 are plain numeric id strings -- none
+    # non-coercible, no ""/NA. The two counts differ because a player can carry
+    # more than one recruit id, not because they disagree.
     # The length-0 -> as.integer(0) behaviour is left alone so already-published
     # rosters keep their existing semantics.
     roster$recruit_ids <- lapply(roster$recruit_ids, function(y) {

--- a/R/espn_cfb_04_roster_creation.R
+++ b/R/espn_cfb_04_roster_creation.R
@@ -40,8 +40,18 @@ games <- purrr::map(years_vec, function(x) {
 
   if (nrow(roster) > 0) {
     roster$season <- x
+    # recruit_ids is a list-column and CFBD returns its elements with mixed
+    # types -- measured on the 2026 roster: 18,515 integer vectors and 12,121
+    # character vectors. csv and rds tolerate that; arrow cannot infer a single
+    # list type and write_parquet() aborts with "Invalid: cannot convert",
+    # which is what failed the 2026-09-07 run at espn_cfb_04_roster.
+    #
+    # Coercing every element to integer is lossless here: all 12,127 character
+    # values are plain numeric id strings, with none non-coercible and no ""/NA.
+    # The length-0 -> as.integer(0) behaviour is left alone so already-published
+    # rosters keep their existing semantics.
     roster$recruit_ids <- lapply(roster$recruit_ids, function(y) {
-      if (length(y) == 0) as.integer(0) else y
+      if (length(y) == 0) as.integer(0) else as.integer(y)
     })
     roster <- roster %>%
       cfbfastR:::make_cfbfastR_data("ESPN CFB Roster from cfbfastR data repository", Sys.time())

--- a/week.R
+++ b/week.R
@@ -281,7 +281,34 @@ arrow::write_parquet(
 )
 
 
+# cfbfastR 3.0.0's pbp engine now attaches its own player-id columns
+# (helper_pbp_attach_player_ids.R / pbp_output_schema.R), and six of those names
+# also come from df_player_stats. On collision dplyr suffixes BOTH sides to
+# .x/.y, so the bare name disappears and the roster joins below -- which join on
+# the bare name -- fail with "Join columns in `x` must be present in the data".
+#
+# That is what broke the 2026-09-07 run at week.R:349 on sack_player_id, with
+# zero HTTP 429s in the run. The adjacent join on sack_taken_player_id succeeded
+# in the same chain precisely because cfbfastR does not emit that name, which is
+# what identified the collision.
+#
+# df_player_stats is the authority for these: they come from
+# cfbd_play_stats_player() ids rather than from parsing play text, and before
+# cfbfastR emitted them this join produced exactly these values. Dropping the
+# pbp-side copies restores that behaviour rather than changing it. any_of() so
+# this neither errors if cfbfastR stops emitting one nor silently breaks if the
+# names drift again.
+pbp_player_id_cols <- c(
+  "fumble_forced_player_id",
+  "fumble_player_id",
+  "fumble_recovered_player_id",
+  "interception_player_id",
+  "pass_breakup_player_id",
+  "sack_player_id"
+)
+
 df_year_players <- pbp_df %>%
+  dplyr::select(-dplyr::any_of(pbp_player_id_cols)) %>%
   dplyr::left_join(
     df_player_stats,
     by = c(


### PR DESCRIPTION
Two independent failures in run [34074863351](https://github.com/sportsdataverse/cfbfastR-data/actions/runs/34074863351), the first dispatch after #20, #21 and cfbfastR#148.

**Neither is throttling.** That run had **zero HTTP 429s** and **zero** `"no play-level player stats data available"` messages, down from 63. The retry work did what it was supposed to; these are different bugs that were sitting behind it.

They surfaced at all because #20's `run_stage()` now fails the job — the run is `failure` with `::error ::espn_cfb_04_roster (2026) failed (exit 1)` instead of the green-and-empty it would have been.

---

## 1. `week.R` — player-id column collision

Failed at `week.R:349`: `Join columns in `x` must be present in the data. ✖ Problem with `sack_player_id``.

cfbfastR 3.0.0's pbp engine now attaches its own player-id columns (`helper_pbp_attach_player_ids.R`, `pbp_output_schema.R`). Six of those names also arrive from `df_player_stats`, so the join at `week.R:284` collides and dplyr suffixes **both** sides to `.x`/`.y`. The bare name stops existing, and the roster joins below — which join on the bare name — fail.

**The tell** was an asymmetry: the join on `sack_taken_player_id` succeeded in the same chain, immediately before the one on `sack_player_id` failed. cfbfastR emits `sack_player_id` (4 occurrences) and does **not** emit `sack_taken_player_id` (0). That difference is the whole bug.

Colliding: `fumble_forced_player_id`, `fumble_player_id`, `fumble_recovered_player_id`, `interception_player_id`, `pass_breakup_player_id`, `sack_player_id`.

`df_player_stats` is the authority for these — they're `cfbd_play_stats_player()` ids rather than ids parsed out of play text, and before cfbfastR emitted them this join produced exactly these values. **Dropping the pbp-side copies restores the previous output rather than changing it.** `any_of()` so it neither errors if cfbfastR stops emitting one nor silently breaks if names drift again.

## 2. `espn_cfb_04_roster_creation.R` — parquet write

Failed with `arrow::write_parquet(roster, ...) -> Invalid: cannot convert`. Not a missing directory — #20's `mkdir -p` worked, it got as far as writing.

`recruit_ids` is a list-column and CFBD returns its elements with **mixed types**. Measured on the live 2026 roster: **18,515 integer vectors and 12,121 character vectors**. csv and rds tolerate that, which is why only the parquet write failed; arrow can't infer a single list type.

Coercing every element to integer is **lossless here**: all 12,127 character values are plain numeric id strings — none non-coercible, no `""`/NA. The `length-0 -> as.integer(0)` behaviour is deliberately left alone so already-published rosters keep their semantics.

---

## Verification

Both fixes were tested against reality, not reasoned about:

**Collision** — reproduced it (join yields `sack_player_id.x` / `sack_player_id.y` and no bare name), confirmed the fix restores the bare column carrying the `df_player_stats` value, and confirmed `any_of()` is a no-op when the column is absent.

**Parquet** — against the **live 2026 roster**:

| | result |
|---|---|
| OLD expression | `FAILED: Invalid: cannot convert` — the exact production error |
| NEW expression | `WROTE` |
| round-trip | 30,636 of 30,636 rows, `recruit_ids` non-empty on every row |

Both files parse.

## After this

Re-dispatch `Update CFB Data` for 2026. The verification that matters is `play_by_play_2026.*` landing on the `cfbfastR_cfb_pbp` tag — that release still has nothing newer than 2026-07-01, and job-green is exactly the signal that misled us for two months.

## Summary by Sourcery

Restore successful 2026 CFB data runs by fixing play-by-play player-ID joins and roster parquet serialization.

Bug Fixes:
- Restore CFB play-by-play processing by resolving player-ID column collisions introduced by cfbfastR 3.0.0.
- Fix roster parquet generation by normalizing mixed-type recruit IDs into integer list elements.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved roster data compatibility by converting player and recruit identifiers into integer values for reliable Parquet output.
  - Resolved play-by-play roster join failures caused by duplicate player identifier fields.
  - Preserved consistent player statistics and sack-related data during roster processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->