### PR TITLE
fix(week): request the full pbp output tier so team_columns can be selected

### DIFF
--- a/week.R
+++ b/week.R
@@ -80,7 +80,19 @@ if (interactive()) {
           year = .x,
           week = .y,
           season_type = "both",
-          epa_wpa = TRUE
+          epa_wpa = TRUE,
+          # cfbfastR 3.0.0 defaults to the v2 engine, which applies output
+          # tiers; the "default" tier drops an 82-column lag/lead set. Four of
+          # those -- lead_pos_team, lag_pos_team, lead_play_type, lag_play_type
+          # -- are named in team_columns and selected with all_of() below, so
+          # the default tier makes that select abort with "Can't subset
+          # elements that don't exist". "full" keeps them.
+          #
+          # This does NOT widen the published release: the final select is a
+          # whitelist of all_of() groups whose union is exactly the 362 columns
+          # already on cfbfastR_cfb_pbp, verified against the 2025 asset. The
+          # extra columns "full" restores are dropped by that select.
+          output = "full"
         )
         p(sprintf("Year %s Week %s", .x, .y))
         return(pbp)
@@ -103,7 +115,19 @@ if (interactive()) {
           year = .x,
           week = .y,
           season_type = "both",
-          epa_wpa = TRUE
+          epa_wpa = TRUE,
+          # cfbfastR 3.0.0 defaults to the v2 engine, which applies output
+          # tiers; the "default" tier drops an 82-column lag/lead set. Four of
+          # those -- lead_pos_team, lag_pos_team, lead_play_type, lag_play_type
+          # -- are named in team_columns and selected with all_of() below, so
+          # the default tier makes that select abort with "Can't subset
+          # elements that don't exist". "full" keeps them.
+          #
+          # This does NOT widen the published release: the final select is a
+          # whitelist of all_of() groups whose union is exactly the 362 columns
+          # already on cfbfastR_cfb_pbp, verified against the 2025 asset. The
+          # extra columns "full" restores are dropped by that select.
+          output = "full"
         )
         p(sprintf("Year %s Week %s", .x, .y))
         return(pbp)


### PR DESCRIPTION
Third cfbfastR 3.0.0 schema drift in this script, found by run [34077157576](https://github.com/sportsdataverse/cfbfastR-data/actions/runs/34077157576) — the first run that got *past* the collision fixed in #22.

**Not throttling.** That run again had zero HTTP 429s. The earlier `left_join` failure is gone and `Invalid: cannot convert` went 1 → 0, so #22 held; the failure simply moved ~600 lines later.

```
Error in `dplyr::select()`: In argument: `dplyr::all_of(team_columns)`
! Can't subset elements that don't exist.
✖ Elements `lead_pos_team`, `lead_play_type`, `lag_pos_team`, and `lag_play_type` don't exist.
```

## Cause

cfbfastR 3.0.0 added output tiers, and **`.pbp_engine(NULL)` now resolves to `"v2"`** — so `cfbd_pbp_data()` already delegates to the v2 engine even though `week.R` passes no `engine`. v2 applies `.pbp_apply_output_schema(output = "default")`, and `"default"` drops the 82-column `.pbp_drop_lag_lead` set. Four of those are named in `team_columns` and selected with `all_of()`, which errors rather than silently dropping.

`output` is forwarded through `...` on that path, so requesting `"full"` is sufficient — no `engine` change needed.

## Why not `any_of()`

Because those four columns **are part of the published schema**. `play_by_play_2025.parquet` on `cfbfastR_cfb_pbp` contains all four. Relaxing `all_of()` → `any_of()` would have made the run succeed while silently removing four columns consumers already receive — trading a loud failure for a quiet contract break.

## Why this doesn't widen the release either

That was the real risk, and it's measured rather than assumed:

| | count |
|---|--:|
| columns `"full"` restores vs `"default"` | 91 |
| of those, already in the 2025 release | 14 |
| **of those, NOT in the release (would be new)** | **77** |

Naively passing `"full"` through to publication would add 77 columns (`lag_play_type2`, `lead_play_text`, `lag_down2`, …). It doesn't, because **`week.R`'s final select is a whitelist** of `all_of()` groups. I computed that union and diffed it against the live published asset:

```
week.R whitelist union : 362 columns
published 2025 release : 362 columns
in whitelist, not in release: 0
in release, not in whitelist: 0
```

Exact match in both directions. `"full"` supplies the intermediates the pipeline needs; the whitelist discards the surplus; the release schema provably cannot change.

## Verification

Tier behaviour exercised directly through `.pbp_apply_output_schema()` — no network, deterministic:

| tier | lag/lead cols kept | ordinary col kept |
|---|---|---|
| `default` | **0 / 4** | ✓ |
| `lean` | **0 / 4** | ✓ |
| `full` | **4 / 4** | ✓ |

Invalid tier values are rejected. `week.R` parses; both `cfbd_pbp_data()` call sites patched.

I first tried confirming this via a live `cfbd_pbp_data()` call, but a full week with `epa_wpa = TRUE` exceeds a 10-minute local budget. Testing the tier function directly isolates the exact mechanism and is the stronger check anyway.

## Known limits

- The whitelist equality is measured against **2025**. If the 2026 frame legitimately lacks some other whitelisted column, `all_of()` will fail again at a different name — same class, different symptom.
- The roster/parquet fix from #22 is **still untested in CI**: `week.R` runs first and has died before reaching stages 01–04 on both attempts.

## Summary by Sourcery

Bug Fixes:
- Request the full cfbfastR play-by-play output tier so required lag/lead team and play-type columns remain available to the weekly processing pipeline.