### PR TITLE
fix(espn stages): refuse to overwrite a good schedule with a failed fetch

### DIFF
--- a/R/espn_cfb_01_pbp_creation.R
+++ b/R/espn_cfb_01_pbp_creation.R
@@ -37,6 +37,30 @@ cfb_pbp_games <- function(y) {
 
   espn_df <- data.frame()
   sched <- cfbfastR:::rds_from_url(paste0("https://raw.githubusercontent.com/sportsdataverse/cfbfastR-raw/main/cfb/schedules/rds/cfb_schedule_", y, ".rds"))
+
+  # cfbfastR:::rds_from_url() returns an EMPTY data.table on a failed download
+  # rather than erroring. cfbfastR-raw only publishes schedules through 2023, so
+  # for 2024+ that URL 404s and `sched` comes back with 0 rows and 0 columns.
+  #
+  # Writing that straight to disk is destructive twice over: it overwrites the
+  # committed cfb/schedules/rds/cfb_schedule_{y}.rds with an empty frame and the
+  # run then COMMITS it (cfb_schedule_2024.rds is 140 bytes on main and
+  # cfb_schedule_2026.rds 137 bytes for exactly this reason), and stage 02
+  # rebuilds the master schedule by listing every file in that directory, so an
+  # empty year silently truncates the master. Downstream, stages 02 and 03 read
+  # the file back and die on `.data$game_json` with an rlang pronoun error that
+  # says nothing about the real cause.
+  #
+  # Refuse to overwrite good data with a failed fetch, and say why.
+  if (!is.data.frame(sched) || nrow(sched) == 0L || !"game_json" %in% names(sched)) {
+    cli::cli_abort(c(
+      "No usable ESPN schedule for {y}.",
+      x = "The cfbfastR-raw schedule fetch returned {nrow(sched)} rows and {ncol(sched)} columns.",
+      i = "cfbfastR-raw publishes cfb/schedules/rds/ only through 2023; {y} 404s.",
+      i = "Refusing to overwrite cfb/schedules/rds/cfb_schedule_{y}.rds with an empty frame."
+    ))
+  }
+
   ifelse(!dir.exists(file.path("cfb/schedules")), dir.create(file.path("cfb/schedules")), FALSE)
   ifelse(!dir.exists(file.path("cfb/schedules/rds")), dir.create(file.path("cfb/schedules/rds")), FALSE)
   ifelse(!dir.exists(file.path("cfb/schedules/parquet")), dir.create(file.path("cfb/schedules/parquet")), FALSE)

--- a/R/espn_cfb_02_team_box_creation.R
+++ b/R/espn_cfb_02_team_box_creation.R
@@ -39,6 +39,18 @@ cfb_team_box_games <- function(y) {
   espn_df <- data.frame()
   sched <- readRDS(paste0("cfb/schedules/rds/cfb_schedule_", y, ".rds"))
 
+  # stage 01 refuses to write an empty schedule, but a previously-committed
+  # empty file can still be on disk (cfb_schedule_2024.rds and _2026.rds are
+  # both empty on main). Fail with the cause rather than an rlang pronoun error
+  # from filter(.data$game_json).
+  if (!is.data.frame(sched) || nrow(sched) == 0L || !"game_json" %in% names(sched)) {
+    cli::cli_abort(c(
+      "No usable ESPN schedule on disk for {y}.",
+      x = "cfb/schedules/rds/cfb_schedule_{y}.rds has {nrow(sched)} rows and {ncol(sched)} columns.",
+      i = "cfbfastR-raw publishes schedules only through 2023; stage 01 cannot build {y}."
+    ))
+  }
+
   season_team_box_list <- sched %>%
     dplyr::filter(.data$game_json == TRUE) %>%
     dplyr::pull("game_id")

--- a/R/espn_cfb_03_player_box_creation.R
+++ b/R/espn_cfb_03_player_box_creation.R
@@ -38,6 +38,18 @@ cfb_player_box_games <- function(y) {
   espn_df <- data.frame()
   sched <- readRDS(paste0("cfb/schedules/rds/cfb_schedule_", y, ".rds"))
 
+  # stage 01 refuses to write an empty schedule, but a previously-committed
+  # empty file can still be on disk (cfb_schedule_2024.rds and _2026.rds are
+  # both empty on main). Fail with the cause rather than an rlang pronoun error
+  # from filter(.data$game_json).
+  if (!is.data.frame(sched) || nrow(sched) == 0L || !"game_json" %in% names(sched)) {
+    cli::cli_abort(c(
+      "No usable ESPN schedule on disk for {y}.",
+      x = "cfb/schedules/rds/cfb_schedule_{y}.rds has {nrow(sched)} rows and {ncol(sched)} columns.",
+      i = "cfbfastR-raw publishes schedules only through 2023; stage 01 cannot build {y}."
+    ))
+  }
+
   season_player_box_list <- sched %>%
     dplyr::filter(.data$game_json == TRUE) %>%
     dplyr::pull("game_id")


### PR DESCRIPTION
Run [34079239613](https://github.com/sportsdataverse/cfbfastR-data/actions/runs/34079239613) **published `play_by_play_2026` successfully** — the original outage is fixed — but still failed, at stages 02 and 03:

```
Caused by error in `dplyr::filter()` -> `.data$game_json`
rlang_error_data_pronoun_not_found
```

## Root cause is upstream; the local handling of it is destructive

**`cfbfastR-raw` publishes `cfb/schedules/rds/` only through `cfb_schedule_2023.rds`.** 2024, 2025 and 2026 don't exist and the URL 404s.

`cfbfastR:::rds_from_url()` returns an **empty data.table on a failed download** rather than erroring. So stage 01 received a 0×0 frame and wrote it straight over `cfb/schedules/rds/cfb_schedule_{y}.rds` — and the run **committed it**.

On `main` right now:

| year | state |
|---|---|
| 2004–2022 | healthy (~300KB each) |
| 2023 | **absent** |
| 2024 | **140 bytes — empty** |
| 2025 | **absent** |
| 2026 | **137 bytes — empty** |

2024 was zeroed by an earlier run (`CFB Data Update (Start: 2024 End: 2024)`), so **this has been quietly corrupting committed schedules for some time** — it isn't damage from tonight.

**It's destructive twice over.** It replaces good committed data with an empty frame, and **stage 02 rebuilds the master schedule by listing every file in that directory** — the exact reason #20 added `cfb/schedules` to the sparse-checkout — so an empty year silently truncates the master rather than failing. Stages 02/03 then read it back and die on a pronoun error that says nothing about the real cause.

## The change

Stage 01 validates the fetch **before writing anything** and aborts with the reason. Stages 02 and 03 validate what they read, since an already-committed empty file can still be on disk.

Neither invents a schedule. **2024–2026 remain unbuildable until `cfbfastR-raw` publishes them** — but the failure now names the gap instead of corrupting data on the way past it.

## Verification

Guard exercised against **real blobs from `main`**, not synthetic stand-ins:

| input | result |
|---|---|
| committed empty 2026 schedule (0×0) | **REFUSED** |
| 0×0 `data.table` (the `rds_from_url` failure shape) | **REFUSED** |
| frame with rows but no `game_json` | **REFUSED** |
| healthy 2022 schedule, 896 rows | **ACCEPTED** |

All three files parse.

## Follow-up this does not cover

- **`cfbfastR-raw` needs to publish 2024–2026 schedules.** That's the actual fix for the box-score stages and it's producer-side, outside this repo.
- The two committed empty files (`cfb_schedule_2024.rds`, `cfb_schedule_2026.rds`) are still empty. Nothing to restore them from — git history shows 2024 was *created* empty, never good — so they need regenerating from the producer, not reverting.

## Summary by Sourcery

Reject unusable ESPN schedules before they can corrupt committed data or trigger misleading downstream failures.

Bug Fixes:
- Prevent failed or empty ESPN schedule fetches from overwriting existing schedule files.
- Fail early with actionable errors when stages 02 and 03 encounter unusable schedules instead of producing misleading downstream errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added clear validation errors when season schedules are unavailable, empty, malformed, or missing required game information.
  - Prevented failed schedule downloads from overwriting valid saved schedule data.
  - Improved reliability of team and player box-score processing by stopping early when schedule data is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->