### PR TITLE
fix(driver): skip the espn_cfb_0*.R stages by default

### DIFF
--- a/.github/workflows/daily_cfb.yml
+++ b/.github/workflows/daily_cfb.yml
@@ -105,6 +105,11 @@ jobs:
           # < 1 value. Set the repository variable CFBD_WORKERS to re-tune the
           # pace from the GitHub UI without touching code.
           CFBD_WORKERS: ${{ vars.CFBD_WORKERS }}
+          # The espn_cfb_0*.R stages are off unless this is "1". They depend on
+          # cfbfastR-raw schedules, which stop at 2023, and their release tags
+          # are already served by cfbfastR-cfb-data. Set the repository variable
+          # RUN_ESPN_STAGES=1 to turn them back on.
+          RUN_ESPN_STAGES: ${{ vars.RUN_ESPN_STAGES }}
         run: |
           echo $(pwd)
           bash scripts/daily_cfb_R_processor.sh -s ${{ env.START_YEAR }} -e ${{ env.END_YEAR }}

--- a/scripts/daily_cfb_R_processor.sh
+++ b/scripts/daily_cfb_R_processor.sh
@@ -80,10 +80,36 @@ do
     git config --local user.email "action@github.com"
     git config --local user.name "Github Action"
     run_stage "week.R ($i)"            Rscript week.R -s $i -e $i
-    run_stage "espn_cfb_01_pbp ($i)"   Rscript R/espn_cfb_01_pbp_creation.R -s $i -e $i
-    run_stage "espn_cfb_02_team ($i)"  Rscript R/espn_cfb_02_team_box_creation.R -s $i -e $i
-    run_stage "espn_cfb_03_player ($i)" Rscript R/espn_cfb_03_player_box_creation.R -s $i -e $i
-    run_stage "espn_cfb_04_roster ($i)" Rscript R/espn_cfb_04_roster_creation.R -s $i -e $i
+
+    # The four espn_cfb_0*.R stages are OFF by default.
+    #
+    # They read cfb/schedules/rds/cfb_schedule_{y}.rds, which stage 01 fetches
+    # from cfbfastR-raw -- and cfbfastR-raw publishes schedules only through
+    # 2023. For 2024+ that URL 404s, so stages 01-03 cannot succeed at all and
+    # stage 01 additionally overwrote the committed schedule with the empty
+    # frame rds_from_url() returns on failure (cfb_schedule_2024.rds is 140
+    # bytes on main for exactly that reason).
+    #
+    # Nothing is lost by skipping them, verified against the live release tags:
+    #   01 -> espn_cfb_pbp          also published by cfbfastR-cfb-data (python), 73 assets, current
+    #   02 -> espn_cfb_team_boxscores    0 assets, has never published
+    #   03 -> espn_cfb_player_boxscores  0 assets, has never published
+    #   03 -> espn_cfb_schedules    also published by the python repo, 95 assets, current
+    #   04 -> espn_cfb_rosters      also published by the python repo, 76 assets, current
+    #
+    # Stage 04 does work -- it published rosters in run 34079239613 -- and is
+    # disabled only because the python repo already covers its tag. Set
+    # RUN_ESPN_STAGES=1 to re-enable all four once cfbfastR-raw publishes
+    # 2024+ schedules; the guards in those scripts will refuse to run against a
+    # missing or empty schedule rather than corrupt one.
+    if [ "${RUN_ESPN_STAGES:-0}" = "1" ]; then
+      run_stage "espn_cfb_01_pbp ($i)"   Rscript R/espn_cfb_01_pbp_creation.R -s $i -e $i
+      run_stage "espn_cfb_02_team ($i)"  Rscript R/espn_cfb_02_team_box_creation.R -s $i -e $i
+      run_stage "espn_cfb_03_player ($i)" Rscript R/espn_cfb_03_player_box_creation.R -s $i -e $i
+      run_stage "espn_cfb_04_roster ($i)" Rscript R/espn_cfb_04_roster_creation.R -s $i -e $i
+    else
+      echo "espn_cfb_0[1-4] stages skipped (RUN_ESPN_STAGES != 1); their tags are served by cfbfastR-cfb-data"
+    fi
     sdv_commit_push "CFB Data Update (Start: $i End: $i)" . || PUSH_RC=1
 done
 


### PR DESCRIPTION
Turns off the four `espn_cfb_0*.R` stages in the daily driver. `week.R` is unaffected and still runs every time — it's what produces `cfbfastR_cfb_pbp`, which now publishes 2026 (35,248 plays, 201 games).

## Why they can't work

They read `cfb/schedules/rds/cfb_schedule_{y}.rds`, which stage 01 fetches from **`cfbfastR-raw` — which publishes schedules only through `cfb_schedule_2023.rds`**. For 2024+ that URL 404s, so stages 01–03 cannot succeed at all. Before #24, stage 01 also *overwrote* the committed schedule with the empty frame `rds_from_url()` returns on failure.

## Nothing is lost — checked against the live tags, not assumed

| stage | tag | also published by python repo? | live state |
|---|---|---|---|
| 01 | `espn_cfb_pbp` | ✅ | 73 assets, current |
| 02 | `espn_cfb_team_boxscores` | ❌ | **0 assets — has never published** |
| 03 | `espn_cfb_player_boxscores` | ❌ | **0 assets — has never published** |
| 03 | `espn_cfb_schedules` | ✅ | 95 assets, current |
| 04 | `espn_cfb_rosters` | ✅ | 76 assets, current |

Every tag that has ever carried data is also served by `cfbfastR-cfb-data`, which is healthy and refreshed 32 CFB tags on 2026-09-06. The two tags unique to these stages have never published anything.

**Stage 04 is the one that actually works** — it published rosters in run [34079239613](https://github.com/sportsdataverse/cfbfastR-data/actions/runs/34079239613), which is also what confirmed #22's arrow fix in CI. I'd earlier reported that fix as unverified; it isn't. Stage 04 is disabled only because the python repo already serves its tag, not because it's broken.

## Gated, not deleted

`RUN_ESPN_STAGES=1` re-enables all four. The workflow forwards `vars.RUN_ESPN_STAGES`, so it's a repository-variable flip with no code change — same pattern as `CFBD_WORKERS` in #21.

That matters because the block is upstream and temporary: once `cfbfastR-raw` publishes 2024+ schedules, flip the variable. The guards from #24 mean re-enabling against a missing or empty schedule now **fails loudly instead of corrupting one**.

## Verification

- `bash -n` clean; workflow YAML parses with all three `env` entries present.
- Gate exercised on all branches: `week.R` runs in every case; stages skipped for unset, `"0"` and `"abc"`; all four run only for `"1"`.

## Still outstanding, upstream

`cfbfastR-raw` needs to publish `cfb_schedule_{2024,2025,2026}.rds`. Also note `cfb_schedule_2024.rds` (140 bytes) and `cfb_schedule_2026.rds` (137 bytes) are still empty on `main` — git history shows 2024 was *created* empty, never good, so they need regenerating from the producer rather than reverting.

## Summary by Sourcery

Make the ESPN data stages opt-in while preserving weekly processing and allowing safe re-enablement when upstream schedules are restored.

Bug Fixes:
- Prevent the daily driver from running ESPN stages that depend on unavailable schedules and could otherwise fail or overwrite schedule data with empty results.

Enhancements:
- Keep the weekly data stage running while making the four ESPN stages opt-in through the RUN_ESPN_STAGES repository variable, with explicit re-enablement once upstream schedules are available.

Tests:
- Verify the stage gate behavior for unset, disabled, invalid, and enabled variable values, while retaining execution of the weekly stage.